### PR TITLE
Ignore case when validating headers.

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -218,7 +218,7 @@ func validateRequestHeaders(requestHeaders string, config Config) bool {
 		match := false
 
 		for _, value := range config.requestHeaders {
-			if value == header {
+			if strings.ToLower(value) == strings.ToLower(header) {
 				match = true
 				break
 			}

--- a/cors_test.go
+++ b/cors_test.go
@@ -109,6 +109,7 @@ func TestPreflightRequest(t *testing.T) {
 	req.Header.Set(OriginKey, "http://files.testing.com")
 	req.Header.Set(RequestMethodKey, "GET")
 	req.Header.Set(RequestHeadersKey, "Content-Type")
+	req.Header.Set(RequestHeadersKey, "accept")
 
 	router := gin.New()
 


### PR DESCRIPTION
HTTP headers are case insensitive (RFC2616, 4.2), therefore, I think
case should be ignored when validating the headers.