### PR TITLE
ValidateRequestHeaders now not only accept ", " as separator

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -239,7 +239,7 @@ func validateRequestHeaders(requestHeaders string, config Config) bool {
 
 	for _, header := range headers {
 		match := false
-		header = strings.ToLower(header)
+		header = strings.ToLower(strings.Trim(header, " \t\r\n"))
 
 		for _, value := range config.requestHeaders {
 			if value == header {


### PR DESCRIPTION
see RFC2616:
message-header = field-name ":" [ field-value ]
       field-name     = token
       field-value    = *( field-content | LWS )

CR             = <US-ASCII CR, carriage return (13)>
LF             = <US-ASCII LF, linefeed (10)>
SP             = <US-ASCII SP, space (32)>
HT             = <US-ASCII HT, horizontal-tab (9)>
CRLF           = CR LF
LWS            = [CRLF] 1*( SP | HT )