### PR TITLE
bugfix: validateRequestHeaders split on ', ' in place of ','

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -235,7 +235,7 @@ func validateRequestHeaders(requestHeaders string, config Config) bool {
 		return true
 	}
 
-	headers := strings.Split(requestHeaders, ", ")
+	headers := strings.Split(requestHeaders, ",")
 
 	for _, header := range headers {
 		match := false


### PR DESCRIPTION
Sorry but I forgot that on my previous commit